### PR TITLE
Add a long touch event

### DIFF
--- a/src/CraftPlugin.ts
+++ b/src/CraftPlugin.ts
@@ -189,6 +189,8 @@ export default class CraftPlugin {
   }
 
   public close() {
+    clearTimeout(this.touchTimer);
+    this.touchTimer = undefined;
     this.emitter.removeAllListeners();
     this.ws.close();
   }


### PR DESCRIPTION
If we want to determine the difference between touching the crown just to trigger an action vs touching it to perform a rotation, we would have to modify the plugin slightly.

Thus, this PR adds a `longTouch` event, which fires if you touch and hold the crown for 1 second (and thus if you quickly release or turn the crown then it won't trigger the `longTouch` event).